### PR TITLE
Add WebSocket Secure (WSS/TLS) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ endif ()
 
 # Include our cmake macros
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
-include (cmake/cppcheck-target-cmake/FindCPPCHECK)
-include (cmake/cppcheck-target-cmake/CPPCheck)
-include (cmake/StyleCheck)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppcheck-target-cmake/FindCPPCHECK")
+    include (cmake/cppcheck-target-cmake/FindCPPCHECK)
+    include (cmake/cppcheck-target-cmake/CPPCheck)
+endif()
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/StyleCheck.cmake")
+    include (cmake/StyleCheck)
+endif()
 
 # Detect clang. Not officially reported by cmake.
 execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "-v" ERROR_VARIABLE CXX_VER_STDERR)
@@ -75,16 +79,27 @@ endif ()
 
 # find_package(ZLIB)
 
+# OpenSSL for TLS/WSS support
+find_package(OpenSSL REQUIRED)
+if(OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    message(STATUS "OpenSSL found: ${OPENSSL_VERSION}")
+endif()
+
 # Build
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_link_libraries (${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries (${PROJECT_NAME} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES})
 # target_link_libraries (${PROJECT_NAME} ${ZLIB_LIBRARIES})
 
 set_target_properties (${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
 # CppCheck
-cppcheck_target_sources (${PROJECT_NAME})
+if(COMMAND cppcheck_target_sources)
+    cppcheck_target_sources (${PROJECT_NAME})
+endif()
 
 # StyleCheck
-add_style_check_target (${PROJECT_NAME} "${FILES}")
+if(COMMAND add_style_check_target)
+    add_style_check_target (${PROJECT_NAME} "${FILES}")
+endif()

--- a/WSS_USAGE.md
+++ b/WSS_USAGE.md
@@ -1,0 +1,185 @@
+# WebSocket Secure (WSS) Support
+
+This document describes how to use the WSS (WebSocket Secure) feature in the slither server.
+
+## Overview
+
+The server now supports both regular WebSocket (ws://) and secure WebSocket (wss://) connections. By default, the server runs in ws:// mode, but you can enable wss:// mode by providing TLS certificates.
+
+## Requirements
+
+- OpenSSL development libraries
+- Valid TLS/SSL certificate and private key files
+
+## Installation
+
+### Install Dependencies
+
+On Ubuntu/Debian:
+```bash
+sudo apt-get update
+sudo apt-get install -y libboost-all-dev libssl-dev
+```
+
+On macOS (using Homebrew):
+```bash
+brew install boost openssl
+```
+
+### Build the Server
+
+```bash
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc)
+```
+
+## Usage
+
+### Running with WSS (Secure WebSocket)
+
+To enable WSS support, use the `--tls` flag along with certificate and key paths:
+
+```bash
+./bin/slither_server --tls --cert /path/to/certificate.pem --key /path/to/private-key.pem
+```
+
+You can also specify a custom port:
+
+```bash
+./bin/slither_server --tls --cert /path/to/certificate.pem --key /path/to/private-key.pem --port 8443
+```
+
+### Running without WSS (Regular WebSocket)
+
+To run the server without TLS (default behavior):
+
+```bash
+./bin/slither_server
+```
+
+Or with a custom port:
+
+```bash
+./bin/slither_server --port 8080
+```
+
+## Command-Line Options
+
+- `--tls`: Enable TLS/SSL (WSS) support
+- `--cert <path>`: Path to TLS certificate file (required when --tls is enabled)
+- `--key <path>`: Path to TLS private key file (required when --tls is enabled)
+- `--port, -p <port>`: Bind port (default: 8080)
+- `--verbose, -v`: Set verbose output
+- `--debug, -d`: Enable debug mode
+- `--help, -h`: Print help message
+
+## Generating Self-Signed Certificates (for testing)
+
+For development and testing purposes, you can generate self-signed certificates:
+
+```bash
+# Generate private key
+openssl genrsa -out server-key.pem 2048
+
+# Generate certificate signing request
+openssl req -new -key server-key.pem -out server.csr
+
+# Generate self-signed certificate (valid for 365 days)
+openssl x509 -req -days 365 -in server.csr -signkey server-key.pem -out server-cert.pem
+```
+
+Then run the server:
+
+```bash
+./bin/slither_server --tls --cert server-cert.pem --key server-key.pem
+```
+
+**Note:** Self-signed certificates will generate browser warnings. For production use, obtain a certificate from a trusted Certificate Authority (CA) like Let's Encrypt.
+
+## Client Connection
+
+### Connecting with WSS
+
+When the server is running with `--tls`, clients should connect using the `wss://` protocol:
+
+```javascript
+const socket = new WebSocket('wss://your-server:8443');
+```
+
+### Connecting without WSS
+
+When the server is running without `--tls`, clients should use the `ws://` protocol:
+
+```javascript
+const socket = new WebSocket('ws://your-server:8080');
+```
+
+## Security Recommendations
+
+1. **Always use WSS in production**: Regular WebSocket connections (ws://) are unencrypted and vulnerable to eavesdropping.
+
+2. **Use valid certificates**: Obtain certificates from a trusted CA for production deployments.
+
+3. **Keep certificates updated**: Monitor certificate expiration dates and renew them before they expire.
+
+4. **Secure private keys**: Protect your private key files with appropriate file permissions:
+   ```bash
+   chmod 600 /path/to/private-key.pem
+   ```
+
+5. **Use strong cipher suites**: The server is configured to disable SSLv2 and SSLv3, which have known vulnerabilities.
+
+## Troubleshooting
+
+### "error: --cert and --key are required when --tls is enabled"
+
+Make sure you provide both `--cert` and `--key` parameters when using `--tls`:
+
+```bash
+./bin/slither_server --tls --cert certificate.pem --key private-key.pem
+```
+
+### "TLS initialization error: ..."
+
+Check that:
+- Certificate and key files exist at the specified paths
+- Certificate and key files are readable by the server process
+- Certificate and key files are in PEM format
+- The private key matches the certificate
+
+### Connection refused or timeout
+
+Ensure:
+- The server is running
+- The port is not blocked by a firewall
+- You're using the correct protocol (wss:// vs ws://)
+- The hostname/IP address is correct
+
+## Technical Details
+
+The server uses:
+- **WebSocket++ library**: For WebSocket protocol implementation
+- **Boost.Asio**: For asynchronous I/O and SSL/TLS support
+- **OpenSSL**: For TLS/SSL cryptographic operations
+- **TLS version**: TLS 1.2 by default
+- **Disabled protocols**: SSLv2, SSLv3 (known security vulnerabilities)
+
+## Example
+
+Complete example with all options:
+
+```bash
+# Generate test certificates
+openssl genrsa -out test-key.pem 2048
+openssl req -new -x509 -key test-key.pem -out test-cert.pem -days 365
+
+# Run server with WSS on port 8443 with debug mode
+./bin/slither_server --tls --cert test-cert.pem --key test-key.pem --port 8443 --debug --verbose
+
+# Connect from browser console
+const ws = new WebSocket('wss://localhost:8443');
+ws.onopen = () => console.log('Connected!');
+ws.onmessage = (event) => console.log('Message:', event.data);
+```

--- a/src/server/config.cc
+++ b/src/server/config.cc
@@ -19,7 +19,13 @@ IncomingConfig ParseCommandLine(const int argc, const char *const *argv) {
       "port,p", po::value<uint16_t>(&config.port)->default_value(config.port),
       "bind port")("debug,d",
                    po::bool_switch(&config.debug)->default_value(config.debug),
-                   "enable debug mode");
+                   "enable debug mode")(
+      "tls", po::bool_switch(&config.use_tls),
+      "enable TLS/SSL (WSS) support")(
+      "cert", po::value<std::string>(&config.tls_cert_file),
+      "path to TLS certificate file (required when --tls is enabled)")(
+      "key", po::value<std::string>(&config.tls_key_file),
+      "path to TLS private key file (required when --tls is enabled)");
 
   po::options_description conf("Configuration");
   conf.add_options()(
@@ -50,6 +56,14 @@ IncomingConfig ParseCommandLine(const int argc, const char *const *argv) {
     std::cerr << "Usage: slither_server [OPTIONS]\n";
     std::cerr << cmdline_options << '\n';
     exit(1);
+  }
+
+  // Validate TLS options
+  if (config.use_tls) {
+    if (config.tls_cert_file.empty() || config.tls_key_file.empty()) {
+      std::cerr << "error: --cert and --key are required when --tls is enabled\n";
+      exit(1);
+    }
   }
 
   return config;

--- a/src/server/config.h
+++ b/src/server/config.h
@@ -3,7 +3,7 @@
 
 #include "game/config.h"
 
-#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/config/asio.hpp>
 // #include <websocketpp/extensions/permessage_deflate/enabled.hpp>
 
 using websocketpp::log::alevel;
@@ -16,6 +16,10 @@ struct IncomingConfig {
   bool version = false;
   bool verbose = false;
   bool debug = false;
+  bool use_tls = false;
+
+  std::string tls_cert_file;
+  std::string tls_key_file;
 
   WorldConfig world;
 };

--- a/src/server/game.h
+++ b/src/server/game.h
@@ -45,6 +45,7 @@ class GameServer {
 
  private:
   void on_socket_init(connection_hdl, boost::asio::ip::tcp::socket &s);  // NOLINT(runtime/references)
+  websocketpp::lib::shared_ptr<boost::asio::ssl::context> on_tls_init(connection_hdl hdl);
   void on_open(connection_hdl hdl);
   void on_message(connection_hdl hdl, message_ptr ptr);
   void on_close(connection_hdl hdl);


### PR DESCRIPTION
This commit adds full support for secure WebSocket connections (wss://) to the slither server using TLS/SSL encryption.

Changes:
- Updated WebSocket++ configuration from asio_no_tls to asio (TLS-enabled)
- Added command-line options: --tls, --cert, --key
- Added TLS certificate and key file configuration fields
- Implemented on_tls_init handler for TLS context initialization
- Configured TLS to use TLS 1.2 and disable insecure SSLv2/SSLv3
- Added OpenSSL dependency to CMake configuration
- Made cppcheck and style check targets optional in CMake
- Added comprehensive WSS_USAGE.md documentation

The server now supports both ws:// (default) and wss:// (with --tls flag). When TLS is enabled, both --cert and --key parameters are required.

Usage:
  # Without TLS (default)
  ./bin/slither_server --port 8080

  # With TLS/WSS
  ./bin/slither_server --tls --cert cert.pem --key key.pem --port 8443

Technical details:
- TLS version: TLS 1.2
- Disabled protocols: SSLv2, SSLv3 (security vulnerabilities)
- Certificate format: PEM
- Uses Boost.Asio SSL context with OpenSSL backend